### PR TITLE
Potential fix for code scanning alert no. 6: Artifact poisoning

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -12,6 +12,9 @@ jobs:
     # dependabot should not have SONAR_TOKEN
     if: github.actor != 'dependabot[bot]' && github.repository_owner == 'remsfal' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event != 'pull_request_target'
     steps:
+      - name: Create artifact temp directory
+        if: github.event.workflow_run.event == 'pull_request'
+        run: mkdir -p ${{ runner.temp }}/artifacts/
       - name: Download PR number artifact
         if: github.event.workflow_run.event == 'pull_request'
         uses: dawidd6/action-download-artifact@v11
@@ -19,12 +22,13 @@ jobs:
           workflow: CI Build
           run_id: ${{ github.event.workflow_run.id }}
           name: PR_NUMBER
+          path: ${{ runner.temp }}/artifacts/
       - name: Read PR_NUMBER.txt
         if: github.event.workflow_run.event == 'pull_request'
         id: pr_number
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./PR_NUMBER.txt
+          path: ${{ runner.temp }}/artifacts/PR_NUMBER.txt
       - name: Request GitHub API for PR data
         if: github.event.workflow_run.event == 'pull_request'
         uses: octokit/request-action@v2.x


### PR DESCRIPTION
Potential fix for [https://github.com/remsfal/remsfal.github.io/security/code-scanning/6](https://github.com/remsfal/remsfal.github.io/security/code-scanning/6)

To fix the problem, you should always treat downloaded artifact contents as untrusted. The best way to mitigate artifact poisoning is to extract all artifact contents into a dedicated temporary directory (e.g., `${{ runner.temp }}/artifacts/`), instead of the default workspace, which prevents accidental overwriting of critical files in your project. Change the workflow so that the artifact download step specifies the `path` to this temporary directory. You should then reference the artifact in subsequent steps relative to this directory, so untrusted files are never intermingled with trusted project files. Specifically:  
- Insert a step before the artifact download to create the temp directory.
- Add the `path` key to the artifact downloading step, setting it to `${{ runner.temp }}/artifacts/`.
- Update the artifact reading step to use the file path within the temp directory: `${{ runner.temp }}/artifacts/PR_NUMBER.txt`.

Only steps within the provided snippet should be changed: lines involving artifact download (`dawidd6/action-download-artifact`), reading the file (`juliangruber/read-file-action@v1`), and any earlier directory setup in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
