### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,6 +54,8 @@ jobs:
 
   check-branches:
     name: "Check Pull Request Conditions"
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/remsfal/remsfal.github.io/security/code-scanning/12](https://github.com/remsfal/remsfal.github.io/security/code-scanning/12)

To fix the problem, add a `permissions` block to the `check-branches` job in `.github/workflows/ci-build.yml` and set it to the least privilege necessary for the job to function. In this case, since the job only runs scripts to check branch names and does not modify content or interact with GitHub APIs that require write permissions, the minimal permission is `contents: read`.  

Specifically, edit the `check-branches` job definition block (line 55 or 56) and insert the following:
```yaml
permissions:
  contents: read
```
Directly below the job name (`name: ...`) and above `runs-on:`. No imports or additional definitions are required for YAML workflow files; only indentation and YAML syntax consistency matter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
