### PR TITLE
Potential fix for code scanning alert no. 14: Code injection

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -63,10 +63,11 @@ jobs:
         id: pr_by_branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           pr_json=$(gh pr list \
             --repo "${{ github.event.workflow_run.repository.full_name }}" \
-            --head "${{ github.event.workflow_run.head_branch }}" \
+            --head "$HEAD_BRANCH" \
             --state all \
             --json number,headRefName,baseRefName \
             --limit 1)


### PR DESCRIPTION
Potential fix for [https://github.com/remsfal/remsfal.github.io/security/code-scanning/14](https://github.com/remsfal/remsfal.github.io/security/code-scanning/14)

To fix the command injection risk in line 69, we should avoid referencing `${{ github.event.workflow_run.head_branch }}` directly in the shell command arguments. Instead, define an environment variable (e.g., `HEAD_BRANCH`) at the step level, receiving its value from the workflow expression. Then, use shell variable expansion (`"$HEAD_BRANCH"`) within the command. This ensures special characters (such as quote marks, line breaks, or command separators) are safely handled by the shell and not interpreted as commands. Specifically:  
- In the “Find Pull Request by Branch” step, add an `env:` section assigning `HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}`.  
- In the command, replace `"${{ github.event.workflow_run.head_branch }}"` on line 69 with `"$HEAD_BRANCH"`.  
No changes to the rest of the workflow are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
